### PR TITLE
Remove exception-logger

### DIFF
--- a/lib/comatose_controller.rb
+++ b/lib/comatose_controller.rb
@@ -1,7 +1,5 @@
 # The controller for serving cms content...
 class ComatoseController < ActionController::Base 
-	include ExceptionLogger::ExceptionLoggable # loades the module
-  rescue_from Exception, :with => :log_exception_handler # tells rails to forward the 'Exception' (you can change the type) to the handler of the module
 
   unloadable
   


### PR DESCRIPTION
This commit removes the project's dependency on the unmaintained exception_logger plugin.
